### PR TITLE
Fixed AllowEmptyAtrribute in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Where and how injection occurs can be controlled via attributes. The EmptyString
         /// Prevents the injection of empty string checking.
         /// </summary>
         [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
-        public class AllowEmptyStringAttribute : Attribute
+        public class AllowEmptyAttribute : Attribute
         {
         }
         


### PR DESCRIPTION
Documentation said AllowEmptyStringAttribute, source code is AllowEmptyAttribute.

I prefer AllowEmptyStringAttribute but choose what would break less code :-)
